### PR TITLE
Resolved conflict: removed roguekiller from 'STAGE 3: Disinfect'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 | NAME       | Tron, an automated PC cleanup script                                                        |
 | :--------- | :------------------------------------------------------------------------------------------ |
-| AUTHOR     | vocatus on reddit.com/r/TronScript (`vocatus d0t gate@gmail.com`) // PGP key: `0x07d1490f82a211a2` |
+| AUTHOR     | vocatus on [reddit.com/r/TronScript](https://reddit.com/r/tronscript) (`vocatus d0t gate@gmail.com`) // PGP key: `0x07d1490f82a211a2` |
 | BACKGROUND | Why the name? Tron "Fights for the User"                                               |
 
 # GITHUB ONLY CONTAINS THE TRON SCRIPT - YOU NEED TO DOWNLOAD THE ENTIRE PACKAGE FROM THE SUBREDDIT AT https://www.reddit.com/r/TronScript !!
@@ -31,7 +31,7 @@ I got tired of running these utilities manually and decided to just automate eve
 
 # USE
 
-1. Boot into Safe Mode with Network Support (Safe Mode is not required but is strongly recommended)
+1. [Boot into Safe Mode with Network Support](#safe-mode). Safe Mode is not required but is strongly recommended.
 
 2. Copy `tron.bat` and the `\resources` folder to the target machine and run `tron.bat` as an **ADMINISTRATOR** (Tron does not work if you don't it run as an Administrator)
 
@@ -41,7 +41,7 @@ I got tired of running these utilities manually and decided to just automate eve
 
 By default the master log file is at `C:\Logs\tron\tron.log`. If you want to change this, read the section on changing defaults below.
 
-Tron will briefly check for a newer version when it starts up and notify you if one is found. 
+Tron will briefly check for a newer version when it starts up and notify you if one is found.
 
 Depending how badly the system is infected, it could take anywhere from 3 to 10 hours to run. I've personally observed times between 4-8 hours, and one user reported a run time of 30 hours. Basically set it and forget it.
 
@@ -49,7 +49,7 @@ Depending how badly the system is infected, it could take anywhere from 3 to 10 
 
 Command-line use is fully supported. All flags are optional and can be combined. *
 
-    tron.bat [-a -c -d -e -er -gsl -m -o -p -r -sa -sb -sd -se -sfr -sk 
+    tron.bat [-a -c -d -e -er -gsl -m -o -p -r -sa -sb -sd -se -sfr -sk
               -sm -sp -spr -srr -ss -sw -v -x] | [-h]
 
     -a   Automatic mode (no welcome screen or prompts; implies -e)
@@ -59,51 +59,51 @@ Command-line use is fully supported. All flags are optional and can be combined.
          if this flag is used)
 
     -d   Dry run (run through script without executing any jobs)
-    
+
     -e   Accept EULA (suppress disclaimer warning screen)
-    
+
     -er  Email a report when finished. Requires you to configure SwithMailSettings.xml
-    
+
     -gsl Generate summary logs. These list exactly what files and programs were removed
 
     -h   Display help text
-    
+
     -m   Preserve default Metro apps (don't remove them)
 
     -o   Power off after running (overrides -r)
 
     -p   Preserve power settings (don't reset to Windows default)
-    
+
     -r   Reboot automatically (auto-reboot 15 seconds after completion)
 
     -sa  Skip ALL anti-virus scans (KVRT, MBAM, SAV)
-    
+
     -sb  Skip de-bloat (OEM bloatware removal; implies -m)
 
     -sd  Skip defrag (force Tron to ALWAYS skip Stage 5 defrag)
-    
+
     -se  Skip Event Log clear (don't clear Windows Event Logs)
-    
+
     -sfr Skip filesystem permissions reset (saves time if you're in a hurry)
 
     -sk  Skip Kaspersky Virus Rescue Tool (KVRT) scan
-    
+
     -sm  Skip Malwarebytes Anti-Malware (MBAM) installation
 
     -sp  Skip patches (do not patch 7-Zip, Java Runtime, Adobe Flash or Reader)
-    
+
     -spr Skip page file reset (don't set to "Let Windows manage the page file")
 
     -srr Skip registry permissions reset (saves time if you're in a hurry)
 
     -ss  Skip Sophos Anti-Virus (SAV) scan
-    
+
     -sw  Skip Windows Updates (do not attempt to run Windows Update)
 
     -v   Verbose. Show as much output as possible. NOTE: Significantly slower!
-    
+
     -x   Self-destruct. Tron deletes itself after running and leaves logs intact
-   
+
 \* There is no -UPM flag
 
 
@@ -115,7 +115,9 @@ More details about this function are in the list of all Tron actions at the bott
 
 # SAFE MODE
 
-Microsoft, in their long-standing tradition of breaking useful, heavily-used functionality for no reason, changed how you get into Safe Mode for Windows 8, disabling the traditional F8 method. Tron re-enables the F8 method as part of it's prep tasks (before actually running), but here's how to manually re-enable the old-style boot menu that supports the F8 key. From an admin command prompt, run this command:
+You can [follow these instructions](http://windows.microsoft.com/en-us/windows/start-computer-safe-mode), but basically it involves pressing F8 after restaring your computer.
+
+Unless you are running Windows 8... Microsoft, in their long-standing tradition of breaking useful, heavily-used functionality for no reason, changed how you get into Safe Mode for Windows 8, disabling the traditional F8 method. Tron re-enables the F8 method as part of it's prep tasks (before actually running), but here's how to manually re-enable the old-style boot menu that supports the F8 key. From an admin command prompt, run this command:
 
     bcdedit /set {default} bootmenupolicy legacy
 
@@ -126,7 +128,7 @@ Reboot and you should now be able to use F8 to select Safe Mode. Note that this 
 To have Tron send an email report at completion, edit this file:
 
     \resources\stage_7_wrap-up\email_report\SwithMailSettings.xml
-    
+
 Specify your SMTP server, username, and password. After specifying your settings you can use the -er flag to have Tron send the email report. If you used the `-gsl` flag (generate summary logs) then `tron_removed_files.txt` and `tron_removed_programs.txt` will be attached as well.
 
 Keep in mind the username and password for the email account will be stored in PLAIN TEXT so don't leave it lying around on a system you don't trust.
@@ -145,7 +147,7 @@ If you don't want to use the command-line and don't like Tron's defaults, you ca
   ```
   set LOGFILE=tron.log
   ```
-  
+
 - To change where Tron stores quarantined files, change this path (note: this is currently unused by Tron, setting it has no effect):
   ```
   set QUARANTINE=%LOGPATH%\quarantine
@@ -155,17 +157,17 @@ If you don't want to use the command-line and don't like Tron's defaults, you ca
   ```
   set BACKUPS=%LOGPATH%\backups
   ```
-  
+
 - To change where Tron saves raw unprocessed logs from the various sub-tools, edit this line:
   ```
   set RAW_LOGS=%LOGPATH%\raw_logs
   ```
-  
+
 - To change where Tron saves summary logs (generated if the -gsl flag is used), edit this line:
   ```
   set SUMMARY_LOGS=%LOGPATH%\summary_logs
   ```
-  
+
 - To always run automatically (no welcome screen, implies acceptance of EULA), change this to `yes`:
   ```
   set AUTORUN=no
@@ -175,7 +177,7 @@ If you don't want to use the command-line and don't like Tron's defaults, you ca
   ```
   set DRY_RUN=no
   ```
-  
+
 - To permanently accept the End User License Agreement (suppress display of disclaimer warning screen), change this to `yes`:
   ```
   set EULA_ACCEPTED=no
@@ -190,7 +192,7 @@ If you don't want to use the command-line and don't like Tron's defaults, you ca
   ```
   set GENERATE_SUMMARY_LOGS=no
   ```
-  
+
 - To preserve default Metro apps (don't remove them), change this to `yes`:
   ```
   set PRESERVE_METRO_APPS=no
@@ -210,22 +212,22 @@ If you don't want to use the command-line and don't like Tron's defaults, you ca
   ```
   set AUTO_REBOOT_DELAY=0
   ```
-  
+
 - To skip anti-virus scan engines (MBAM, KVRT, Sophos), change this to `yes`:
   ```
   set SKIP_ANTIVIRUS_SCANS=no
   ```
 
 - To skip OEM debloat, change this to `yes`:
-  ```     
+  ```
   set SKIP_DEBLOAT=no
   ```
-  
+
 - To always skip defrag, regardless whether `C:\` is an SSD or not, change this to `yes`:
   ```
   set SKIP_DEFRAG=no
   ```
-  
+
 - To skip Windows Event Log clearing, change this to `yes`:
   ```
   set SKIP_EVENT_LOG_CLEAR=no
@@ -237,10 +239,10 @@ If you don't want to use the command-line and don't like Tron's defaults, you ca
   ```
 
 - To skip scanning with Kaspersky Virus Rescue Tool (KVRT), change this to `yes`:
-  ``` 
+  ```
   set SKIP_KASPERSKY_SCAN=no
   ```
-  
+
 - To skip installation of Malwarebytes Anti-Malware (MBAM), change this to `yes`:
   ```
   set SKIP_MBAM_INSTALL=no
@@ -270,7 +272,7 @@ If you don't want to use the command-line and don't like Tron's defaults, you ca
   ```
   set SKIP_WINDOWS_UPDATES=no
   ```
-  
+
 - To display as much output as possible (verbose), change this to `yes`:
   ```
   set VERBOSE=no
@@ -309,7 +311,7 @@ If you feel overly charitable:
 
 
 # FULL TRON DESCRIPTION
-The best way to see what Tron does is simply to crack open `Tron.bat` with a text editor (preferably one with syntax highlighting) or on Github and just read the code. Every section has comments explaining exactly what it does, and you don't need to be able to read code to understand it. However, barring that, here's a general description of every action Tron performs.
+The best way to see what Tron does is simply to crack open `Tron.bat` with a text editor (preferably one with syntax highlighting) or [on GitHub and just read the code](https://github.com/bmrf/tron/blob/master/tron.bat). Every section has comments explaining exactly what it does, and you don't need to be able to read code to understand it. However, barring that, here's a general description of every action Tron performs.
 
 ## tron.bat
 Master script that launches all the other tools. It performs a lot of actions on its own, but for any task we can't perform directly, we call an external utility or script
@@ -345,11 +347,11 @@ Master script that launches all the other tools. It performs a lot of actions on
 
 3. **Create System Restore point**: Windows Vista and up only; client OS's only (not supported on Server OS's). Tron creates a system restore snapshot before beginning operations
 
-4. **Rkill**: Rkill is an anti-malware prep tool; it looks for and kills a number of known malware that interfere with removal tools. Rkill will exclude any process listed in `\resources\stage_0_prep\rkill\rkill_process_whitelist.txt` from being closed
+4. **[Rkill](http://www.bleepingcomputer.com/download/rkill/)**: Rkill is an anti-malware prep tool; it looks for and kills a number of known malware that interfere with removal tools. Rkill will exclude any process listed in `\resources\stage_0_prep\rkill\rkill_process_whitelist.txt` from being closed
 
 5. **ProcessKiller**: Utility provided by /u/cuddlychops06 which kills various userland processes. We use this to further kill anything that might interfere with Tron. Specifically, it kills everything in userland with the exception of the following processes: `ClassicShellService.exe`, `explorer.exe`, `dwm.exe`, `cmd.exe`, `mbam.exe`, `teamviewer.exe`, `TeamViewer_Service.exe`, `Taskmgr.exe`, `Teamviewer_Desktop.exe`, `MsMpEng.exe`, `tv_w32.exe`, `VTTimer.exe`, `Tron.bat`, `rkill.exe`, `rkill64.exe`, `rkill.com`, `rkill64.com`, `conhost.exe`, `dashost.exe`, `wget.exe`
 
-6. **Safe mode**: Set system to reboot into Safe Mode with Networking if a reboot occurs. Removes this and resets to normal bootup at the end of the script. Accomplished via this command: 
+6. **Safe mode**: Set system to reboot into Safe Mode with Networking if a reboot occurs. Removes this and resets to normal bootup at the end of the script. Accomplished via this command:
    ```
    bcdedit /set {default} safeboot network
    ```
@@ -358,19 +360,19 @@ Master script that launches all the other tools. It performs a lot of actions on
 
 8. **Check and repair WMI**: Check the WMI interface and attempt repair if broken. Tron uses WMI for a lot of stuff including ISO date format conversion, OEM bloatware removal, and various other things, so having it functioning is critical
 
-9. **McAfee Stinger**: Anti-malware/rootkit/virus standalone scanner from McAfee. Does not support plain-text logs so we save its HTML log to Tron's %LOGPATH%. Tron executes Stinger as follows: 
+9. **[McAfee Stinger](http://www.mcafee.com/us/downloads/free-tools/stinger.aspx)**: Anti-malware/rootkit/virus standalone scanner from McAfee. Does not support plain-text logs so we save its HTML log to Tron's %LOGPATH%. Tron executes Stinger as follows:
 
   ```
   stinger32.exe --GO --SILENT --PROGRAM --REPORTPATH="%LOGPATH%" --RPTALL --DELETE
   ```
 
-10. **TDSS Killer**: Anti-rootkit utility from Kaspersky Labs. Tron executes TDSSKiller as follows:
+10. **[TDSS Killer](http://usa.kaspersky.com/downloads/TDSSKiller)**: Anti-rootkit utility from Kaspersky Labs. Tron executes TDSSKiller as follows:
 
   ```
   tdsskiller.exe -l %TEMP%\tdsskiller.log -silent -tdlfs -dcexact -accepteula -accepteulaksn
   ```
 
-11. **erunt**: Used to backup the registry before beginning a Tron run
+11. **[erunt](http://www.larshederer.homepage.t-online.de/erunt/)**: Used to backup the registry before beginning a Tron run
 
 12. **VSS purge**: Purges oldest set of Volume Shadow Service files (basically snapshot-in-time copies of files). Malware can often hide out here
 
@@ -387,13 +389,13 @@ Master script that launches all the other tools. It performs a lot of actions on
   rundll32.exe inetcpl.cpl,ClearMyTracksByProcess 4351
   ```
 
-2. **CCLeaner**: CCLeaner utility by Piriform. Used to clean temp files before running AV scanners
+2. **[CCLeaner](https://www.piriform.com/ccleaner)**: CCLeaner utility by Piriform. Used to clean temp files before running AV scanners
 
-3. **BleachBit**: BleachBit utility. Used to clean temp files before running AV scanners
+3. **[BleachBit](http://bleachbit.sourceforge.net/)**: BleachBit utility. Used to clean temp files before running AV scanners
 
 4. **TempFileCleanup.bat**: Script I wrote to clean some areas that other tools seem to miss
 
-5. **DriveCleanup.exe**: Cleans unused/not present USB device drivers. Utility from Uwe Sieber ( www.uwe-sieber.de )
+5. **[DriveCleanup.exe](http://www.uwe-sieber.de/drivetools_e.html#drivecleanup)**: Cleans unused/not present USB device drivers. Utility from Uwe Sieber
 
 6. **Clear Windows event logs**: Backs up Windows event logs by default to the LOGPATH directory, then clears all log files
 
@@ -419,18 +421,18 @@ Master script that launches all the other tools. It performs a lot of actions on
 
 ## STAGE 3: Disinfect
 
-1. **Malwarebytes Anti-Malware**: Anti-malware scanner. Because there is no command-line support for MBAM, we simply install it and continue with the rest of the script. This way a tech can click **Scan** whenever they're around, but the script doesn't stall while waiting for user input. Using Tron's `-sa` or `-sm` flags skip this component
+1. **[Malwarebytes Anti-Malware](https://www.malwarebytes.org/)**: Anti-malware scanner. Because there is no command-line support for MBAM, we simply install it and continue with the rest of the script. This way a tech can click **Scan** whenever they're around, but the script doesn't stall while waiting for user input. Using Tron's `-sa` or `-sm` flags skip this component
 
-2. **KVRT**: Kaspersky Virus Removal Tool. Using Tron's `-sa` or `-sk` flags skip this component
+2. **[KVRT](http://www.kaspersky.com/antivirus-removal-tool)**: Kaspersky Virus Removal Tool. Using Tron's `-sa` or `-sk` flags skip this component
 
   ```
   -l %TEMP%\tdsskiller.log -silent -tdlfs -dcexact -accepteula -accepteulaksn
   ```
 
-3. **Sophos Virus Removal Tool**: Command-line anti-virus scanner. Using Tron's `-v` flag gives more verbose output. Using Tron's `-sa` or `-ss` flags skip this component
+3. **[Sophos Virus Removal Tool](https://www.sophos.com/en-us/products/free-tools/virus-removal-tool.aspx)**: Command-line anti-virus scanner. Using Tron's `-v` flag gives more verbose output. Using Tron's `-sa` or `-ss` flags skip this component
 
 
-4. **System File Checker**: Microsoft utility for checking the filesystem for errors and attempting to repair if found. Only run on Windows Vista and up (XP and below require a reboot)
+4. **[System File Checker](https://support.microsoft.com/en-us/kb/929833)**: Microsoft utility for checking the filesystem for errors and attempting to repair if found. Only run on Windows Vista and up (XP and below require a reboot)
 
 
 ## STAGE 4: Repair
@@ -441,7 +443,7 @@ Master script that launches all the other tools. It performs a lot of actions on
 
 3. **Filesystem permissions reset**: Grant `SYSTEM` and `Administrator` users full permissions on everything in the `%WinDir%` directory tree. Using Tron's -sfr flag skips this operation
 
-4. **System File Checker**: Microsoft utility for checking the filesystem for errors and attempting to repair if found. Tron runs this on Windows Vista and up only (XP and below require a reboot) 
+4. **[System File Checker](https://support.microsoft.com/en-us/kb/929833)**: Microsoft utility for checking the filesystem for errors and attempting to repair if found. Tron runs this on Windows Vista and up only (XP and below require a reboot)
 
 5. **chkdsk**: Checks disk for errors and schedules a chkdsk with repair at next reboot
 
@@ -465,14 +467,14 @@ Tron installs or updates these programs:
 ## STAGE 6: Optimize
 
 1. **Page file reset**: Reset the system page file settings to "let Windows manage the page file." Accomplished via this command:
-    
+
     `%WMIC% computersystem where name="%computername%" set AutomaticManagedPagefile=True`
 
     Using the `-spr` flag skips this action
 
 2. **chkdsk**: Checks disk for errors and schedules a chkdsk with repair at next reboot
 
-3. **Defraggler**: Command-line defrag tool from Piriform that's a little faster than the built-in Windows defragmenter
+3. **[Defraggler](https://www.piriform.com/defraggler)**: Command-line defrag tool from Piriform that's a little faster than the built-in Windows defragmenter
 
 
 ## STAGE 7: Wrap-up
@@ -484,21 +486,21 @@ Tron installs or updates these programs:
 ## STAGE 8: Manual tools
 Tron does not run these automatically because most of them don't support command-line use, or are only useful in special cases.
 
-1. **ADSSpy**: Scans for hidden NTFS Alternate Data Streams
+1. **[ADSSpy](http://www.bleepingcomputer.com/download/ads-spy/)**: Scans for hidden NTFS Alternate Data Streams
 
-2. **AdwCleaner**: Popular user-suggested adware removal tool
+2. **[AdwCleaner](https://toolslib.net/downloads/viewdownload/1-adwcleaner/)**: Popular user-suggested adware removal tool
 
-3. **aswMBR**: Rootkit scanner
+3. **[aswMBR](http://public.avast.com/~gmerek/aswMBR.htm)**: Rootkit scanner
 
-4. **autoruns**: Examine and remove programs that run at startup
+4. **[autoruns](https://technet.microsoft.com/en-us/sysinternals/bb963902.aspx)**: Examine and remove programs that run at startup
 
-5. **ComboFix**: The "scorched-earth policy" of malware removal. Only works on Windows XP through Windows 7 (no Win8 or above)
+5. **[ComboFix](http://www.combofix.org/)**: The "scorched-earth policy" of malware removal. Only works on Windows XP through Windows 7 (no Win8 or above)
 
-6. **PCHunter**: Tool to scan for rootkits and other malicious items. Replaces gmer
+6. **[PCHunter](http://www.majorgeeks.com/files/details/pc_hunter.html)**: Tool to scan for rootkits and other malicious items. Replaces gmer
 
-7. **Junkware Removal Tool**: Temp files and random junkware remover
+7. **[Junkware Removal Tool](http://thisisudax.org/)**: Temp files and random junkware remover
 
-8. **Net Adapter Repair**: Utility to repair most aspects of Windows network connections
+8. **[Net Adapter Repair](http://www.bleepingcomputer.com/download/netadapter-repair-all-in-one/)**: Utility to repair most aspects of Windows network connections
 
 9. **Remote Support Reboot Config**: Tool to quickly configure auto-login and other parameters for running Tron via a remote connection. Thanks to reddit.com/user/cuddlychops06
 
@@ -506,7 +508,7 @@ Tron does not run these automatically because most of them don't support command
 
 11. **ServicesRepair.exe**: ESET utility for fixing broken Windows services
 
-12. **TempFileCleaner**: OldTimer utility for cleaning temp files
+12. **[TempFileCleaner](http://addpcs.com/software/tfc/)**: OldTimer utility for cleaning temp files
 
 13. **Tron Reset Tool**: Tool to quickly reset Tron if it gets interrupted or breaks while running
 


### PR DESCRIPTION
Resolved conflicts from https://github.com/bmrf/tron/pull/18

Changes are to `## STAGE 3: Disinfect`, where RogueKiller was removed from the list. I think Atom also removed some whitespace between lines, but it doesn't look like it hurt the markup.