### PR TITLE
Remove *.blf and *.regtrans-ms

### DIFF
--- a/resources/stage_1_tempclean/tempfilecleanup/TempFileCleanup.bat
+++ b/resources/stage_1_tempclean/tempfilecleanup/TempFileCleanup.bat
@@ -93,6 +93,10 @@ if /i "%WIN_VER:~0,9%"=="Microsoft" (
 		del /F /Q "%%x\AppData\Roaming\Microsoft\Windows\Recent\*" 2>NUL
 		del /F /Q "%%x\AppData\Local\Microsoft\Windows\Temporary Internet Files\*" 2>NUL
 		del /F /Q "%%x\My Documents\*.tmp" 2>NUL
+		del /F /Q "%%x\AppData\Local\Microsoft\Windows\*.blf" 2>NUL
+		del /F /Q "%%x\AppData\Local\Microsoft\Windows\*.regtrans-ms" 2>NUL
+		del /F /Q "%%x\*.blf" 2>NUL
+		del /F /Q "%%x\*.regtrans-ms" 2>NUL
 	)
 )
 


### PR DESCRIPTION
These files tend to get overgrown in number and eventually take up quite a bit of disk space. They are not found in XP/2003. The reading I have done about them says they are safe to remove, but you might also want to consider the materials you find.