### PR TITLE
Added 2 entries

### DIFF
--- a/resources/stage_2_de-bloat/oem/programs_to_target_by_name.txt
+++ b/resources/stage_2_de-bloat/oem/programs_to_target_by_name.txt
@@ -35,6 +35,7 @@
 24x7 Help
 3vix%%
 888bar
+ABBYY FineReader
 Advanced Registry%%
 Acer%%
 Adobe Shockwave%%
@@ -51,6 +52,7 @@ AtuZi
 AVG PC TuneUp%%
 AVG Web TuneUp
 AVG 2014%%
+AVG Toolbar
 Baidu PC Faster%%
 Big Fish Games: Game Manager
 Big Fish: Game Manager


### PR DESCRIPTION
Abbyy Finereader - prevents Office 2013+ from opening properly, comes as bloat on printer installations
AVG Toolbar - because AVG and Toolbar