### PR TITLE
Remove temp files that are less than 24 hours old

### DIFF
--- a/resources/stage_1_tempclean/ccleaner/ccleaner.ini
+++ b/resources/stage_1_tempclean/ccleaner/ccleaner.ini
@@ -25,6 +25,7 @@ FinderIncludeStates=1|0|0|0|0|1|1
 (App)Notepad++=True
 (App)Sun Java=True
 RunICS=0
+DelayTemp=0
 (App)Old Prefetch data=True
 ShowCleanWarning=False
 ShowFirefoxCleanWarning=False


### PR DESCRIPTION
By default CCleaner does not remove temp files that are less than 24 hours old (see CCleaner's advanced settings). This changes that so it'll delete those as well.