### PR TITLE
Fix empty logfile with no removed programs

### DIFF
--- a/tron.bat
+++ b/tron.bat
@@ -954,7 +954,7 @@ if /i %DRY_RUN%==no (
 
 		REM If the parsed file is the same as the original, we can assume nothing was removed, so just echo that into the file
 		fc /b %RAW_LOGS%\installed-programs-before.txt %RAW_LOGS%\installed-programs-after.txt >NUL
-		if !ERRORLEVEL!==0 echo No programs were removed.> %SUMMARY_LOGS%\tron_removed_programs.txt
+		if %ERRORLEVEL%==0 echo No programs were removed.> %SUMMARY_LOGS%\tron_removed_programs.txt
 
 		REM Cleanup
 		del /f /q %TEMP%\temp.txt 2>NUL


### PR DESCRIPTION
The if statement used to determine if the before and after programs list
are identical was flawed. %ERRORLEVEL% should be used instead of
!ERRORLEVEL!. You may want to check your other statements to make sure they execute correctly.