### PR TITLE
Fix the removed programs list being empty

### DIFF
--- a/tron.bat
+++ b/tron.bat
@@ -954,7 +954,7 @@ if /i %DRY_RUN%==no (
 
 		REM If the parsed file is the same as the original, we can assume nothing was removed, so just echo that into the file
 		fc /b %RAW_LOGS%\installed-programs-before.txt %RAW_LOGS%\installed-programs-after.txt >NUL
-		if !ERRORLEVEL!==0 echo No programs were removed.> %SUMMARY_LOGS%\tron_removed_programs.txt
+		if %ERRORLEVEL%==0 echo No programs were removed.> %SUMMARY_LOGS%\tron_removed_programs.txt
 
 		REM Cleanup
 		del /f /q %TEMP%\temp.txt 2>NUL


### PR DESCRIPTION
The IF command that ran that inserts the line into the removed program list if it was empty was flawed. The FC program sets an environment variable of ERRORLEVEL with a value of 0 if there's no difference. The IF check used !ERRORLEVEL! instead of %ERRORLEVEL%, which caused it to not execute. You may want to check your other comparisons.