### PR TITLE
Add failsafe for drives that can't be read

### DIFF
--- a/tron.bat
+++ b/tron.bat
@@ -320,6 +320,11 @@ for /f "tokens=1" %%i in ('stage_6_optimize\defrag\smartctl.exe --scan') do (
 	stage_6_optimize\defrag\smartctl.exe %%i -a | %FIND% /i "SandForce" >NUL
 	if "!ERRORLEVEL!"=="0" ENDLOCAL DISABLEDELAYEDEXPANSION && set SSD_DETECTED=yes&& goto freespace_check
 	)
+for /f "tokens=1" %%i in ('stage_6_optimize\defrag\smartctl.exe --scan') do (
+	REM This is a failsafe if drive information cannot be read. See issue #59 on GitHub.
+	stage_6_optimize\defrag\smartctl.exe %%i -a | %FIND% /i "Read Device Identity Failed" >NUL
+	if "!ERRORLEVEL!"=="0" ENDLOCAL DISABLEDELAYEDEXPANSION && set SSD_DETECTED=yes&& goto freespace_check
+	)
 ENDLOCAL DISABLEDELAYEDEXPANSION
 
 


### PR DESCRIPTION
In some rare cases, drive information cannot be automatically read by smartctl, as is the case with issue #59. This adds a failsafe that errs on the side of caution in case this drive actually is an SSD.