### PR TITLE
Only delete Local Storage for websites.

### DIFF
--- a/resources/stage_1_tempclean/tempfilecleanup/TempFileCleanup.bat
+++ b/resources/stage_1_tempclean/tempfilecleanup/TempFileCleanup.bat
@@ -86,7 +86,7 @@ if %WIN_VER_NUM% lss 6.0 (
 		del /F /S /Q "%%x\Local Settings\Application Data\Google\Chrome\User Data\Default\Cache\*" 2>NUL
 		del /F /S /Q "%%x\Local Settings\Application Data\Google\Chrome\User Data\Default\JumpListIconsOld\*" 2>NUL
 		del /F /S /Q "%%x\Local Settings\Application Data\Google\Chrome\User Data\Default\JumpListIcons\*" 2>NUL
-		del /F /S /Q "%%x\Local Settings\Application Data\Google\Chrome\User Data\Default\Local Storage\*" 2>NUL
+		del /F /S /Q "%%x\Local Settings\Application Data\Google\Chrome\User Data\Default\Local Storage\http*.*" 2>NUL
 		del /F /S /Q "%%x\Local Settings\Application Data\Google\Chrome\User Data\Default\Media Cache\*" 2>NUL
 		del /F /S /Q "%%x\Local Settings\Application Data\Microsoft\Internet Explorer\Recovery\*" 2>NUL
 		del /F /S /Q "%%x\Local Settings\Application Data\Microsoft\Terminal Server Client\Cache\*" 2>NUL
@@ -103,7 +103,7 @@ if %WIN_VER_NUM% lss 6.0 (
 		del /F /S /Q "%%x\AppData\Local\Google\Chrome\User Data\Default\Cache\*" 2>NUL
 		del /F /S /Q "%%x\AppData\Local\Google\Chrome\User Data\Default\JumpListIconsOld\*" 2>NUL
 		del /F /S /Q "%%x\AppData\Local\Google\Chrome\User Data\Default\JumpListIcons\*" 2>NUL
-		del /F /S /Q "%%x\AppData\Local\Google\Chrome\User Data\Default\Local Storage\*" 2>NUL
+		del /F /S /Q "%%x\AppData\Local\Google\Chrome\User Data\Default\Local Storage\http*.*" 2>NUL
 		del /F /S /Q "%%x\AppData\Local\Google\Chrome\User Data\Default\Media Cache\*" 2>NUL
 		del /F /S /Q "%%x\AppData\Local\Microsoft\Internet Explorer\Recovery\*" 2>NUL
 		del /F /S /Q "%%x\AppData\Local\Microsoft\Terminal Server Client\Cache\*" 2>NUL


### PR DESCRIPTION
Both CCleaner and Bleachbit deletes the files in `Local Storage` but only the ones that start with `http`.
This is probably because chrome extensions sometimes store their settings in files named like this: `chrome-extension_*.localstorage`
If you delete them you delete all the local settings for those extensions will be gone, I had personally lots of login problems with Lastpass because of this. 

I noticed that you have excluded Lastpass cookies from CCleaner so I figured that these changes would make sense. (But doesn't bleachbit delete those cookies anyway?)

If this isn't a fit for tron then consider it for the standalone temfilecleanup script.