### PR TITLE
Added .gitattributes to deal with line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+*.ps1 eol=crlf
+*.txt eol=crlf
+*.vbs eol=crlf
+*.xml eol=crlf
+*.properties eol=crlf
+*.sites eol=crlf
+*.config eol=crlf
+*.h eol=crlf
+
+
+# Denote all files that are truly binary and should not be modified.
+*.exe binary


### PR DESCRIPTION
Tried to follow [this guide](https://help.github.com/articles/dealing-with-line-endings/), I'm kind of new to this stuff. I added the filetypes that have CRLF when you get them from the official releases, maybe some of them doesn't need to be listed.

The repository might need to be [refreshed](https://help.github.com/articles/dealing-with-line-endings/#refreshing-a-repository-after-changing-line-endings), or maybe your files with the right endings will just stick in the future and it will just work?

Anyway, adding this file is probably a good idea and can't hurt?

EDIT: Tried to download the whole repo as a zip from the [patch branch](https://github.com/Kezxo/tron/tree/patch-1) and the [tron.bat](https://github.com/Kezxo/tron/blob/patch-1/tron.bat) file has CLRF line endings so it looks like it worked.