### PR TITLE
Update .gitattributes with more file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,9 @@
 *.sites eol=crlf
 *.config eol=crlf
 *.h eol=crlf
+*.reg eol=crlf
+*.cfg eol=crlf
+*.ini eol=crlf
 
 
 # Denote all files that are truly binary and should not be modified.


### PR DESCRIPTION
Added some more file types that should have ``CRLF`` line endings based on how they are in the packaged full version.
Some .ini files in the full tron package were not ``CRLF`` like ``winapp2.ini`` and ``ccleaner.ini`` but they are when you get them from the source so it probably doesn't matter.
``bleachbit.ini`` is ``LF`` if you get the installer but ``CRLF`` if you download the portable version so that should be fine also.