### PR TITLE
BAD_RUNPATH: Error message copy-edit to remove abrasiveness. 

### DIFF
--- a/resources/functions/prerun_checks_and_tasks.bat
+++ b/resources/functions/prerun_checks_and_tasks.bat
@@ -81,16 +81,20 @@ if %BAD_RUNPATH%==yes (
 	echo.
 	echo  ERROR
 	echo.
-	echo  ...guess who didn't read the instructions? You.
+	echo  ...Did you read the instructions?
 	echo.
-	echo  Tron is running from a temp directory. Tron cannot run
-	echo  from temp directories as they're some of the first 
-	echo  places to get wiped when the script starts. Run Tron
-	echo  directly from the Desktop. Example of a correct path:
+	echo  Tron is running from a temp directory or other 
+	echo  blacklisted location. Tron cannot run from
+	echo  temp directories as they're some of the first 
+	echo  places to get wiped when the script starts, and
+	echo  there are a few locations reserved for use by Tron.
+	echo.
+	echo  We suggest that you run Tron directly from the Desktop.
+	echo.
+	echo  Example of a correct path:
 	echo.
 	echo   "%USERPROFILE%\Desktop\tron\tron.bat"
 	echo.
-	echo  Go read the instructions, clown.
 	echo.
 	echo  Goodbye.
 	echo.


### PR DESCRIPTION
I encountered this error message while trying to execute from c:\tron.  
This location is NOT mentioned in the documentation as an invalid location.

Since I was running this blind on a remote system that will not have access to user network resources while in safe mode, following the instructions would result in a failed execution. 

The attitude was not appreciated.

I would suggest not calling the user a clown and being abrasive when avoidable.
It turns a small issue that's easily fixed into yet another aggravating point of friction.  

This is actually somewhat more important in this case, considering that people don't run tron when they're having a good day. 

Pissing off users when they have an issue just makes them LESS capable of fixing the issue themselves and increases the likelihood of them not understanding the instructions if they DO go re-read them. 

Then you're left with upset users complaining on reddit or opening spurious bug reports for minor things that they could easily fix themselves..

The really bad ones might even submit a pull request. \<grin\>