### PR TITLE
Metro removal improvement

### DIFF
--- a/resources/stage_2_de-bloat/metro/metro_3rd_party_modern_apps_to_target_by_name.ps1
+++ b/resources/stage_2_de-bloat/metro/metro_3rd_party_modern_apps_to_target_by_name.ps1
@@ -17,7 +17,7 @@ $METRO_3RD_PARTY_MODERN_APPS_TO_TARGET_BY_NAME_SCRIPT_DATE = "2018-05-21"
 
 # Needed for Removal
 $AppxPackages = Get-AppxProvisionedPackage -online | select-object PackageName,Displayname
-$ProPackage = Get-AppxPackage | select-object PackageFullName, Name
+$ProPackage = Get-AppxPackage -AllUsers | select-object PackageFullName, Name
 $Script:AppxCount3rd = 0
 
 # App Removal function

--- a/resources/stage_2_de-bloat/metro/metro_3rd_party_modern_apps_to_target_by_name.ps1
+++ b/resources/stage_2_de-bloat/metro/metro_3rd_party_modern_apps_to_target_by_name.ps1
@@ -17,16 +17,17 @@ $METRO_3RD_PARTY_MODERN_APPS_TO_TARGET_BY_NAME_SCRIPT_DATE = "2018-05-21"
 
 # Needed for Removal
 $AppxPackages = Get-AppxProvisionedPackage -online | select-object PackageName,Displayname
+$ProPackage = Get-AppxPackage | select-object PackageFullName, Name
 $Script:AppxCount3rd = 0
 
 # App Removal function
 Function Remove-App([String]$AppName){
-	If($AppxPackages.DisplayName -match $AppName) {
-		$PackageFullName = (Get-AppxPackage $AppName).PackageFullName
+	If($AppxPackages.DisplayName -match $AppName -or $ProPackage.Name -match $AppName ) {
+		$PackageFullName = ($ProPackage | where {$_.Name -like $AppName}).PackageFullName
 		$ProPackageFullName = ($AppxPackages | where {$_.Displayname -like $AppName}).PackageName
 	
-		If($ProPackageFullName -is [array]){
-			For($i=0 ;$i -lt $ProPackageFullName.Length ;$i++) {
+		If($PackageFullName -is [array]){
+			For($i=0 ;$i -lt $PackageFullName.Length ;$i++) {
 				$Script:AppxCount3rd++
 				$Job = "TronScript3rd$AppxCount3rd"
 				$PackageF = $PackageFullName[$i]

--- a/resources/stage_2_de-bloat/metro/metro_Microsoft_modern_apps_to_target_by_name.ps1
+++ b/resources/stage_2_de-bloat/metro/metro_Microsoft_modern_apps_to_target_by_name.ps1
@@ -1,8 +1,8 @@
 <#
 Purpose:       Script to remove many of the pre-loaded Microsoft Metro "modern app" bloatware. Called by Tron in Stage 2: De-bloat
-               Add any AppX package names to the $PackagesToRemove array to target them for removal
+               Add any AppX uninstall commands to this list to target them for removal
 Requirements:  1. Administrator access
-               2. Windows 7 and up
+               2. Windows 8 and up
 Author:        vocatus on reddit.com/r/TronScript ( vocatus.gate at gmail ) // PGP key: 0x07d1490f82a211a2
 Version:       1.1.8 + Add additional user-submitted entries
                1.1.7 + Add Microsoft.GetHelp
@@ -30,12 +30,38 @@ $ErrorActionPreference = "SilentlyContinue"
 $METRO_MICROSOFT_MODERN_APPS_TO_TARGET_BY_NAME_SCRIPT_VERSION = "1.1.8"
 $METRO_MICROSOFT_MODERN_APPS_TO_TARGET_BY_NAME_SCRIPT_DATE = "2018-03-06"
 
-# Build the removal function
+# Needed for Removal
+$AppxPackages = Get-AppxProvisionedPackage -online | select-object PackageName,Displayname
+$Script:AppxCountMS = 0
+
+# App Removal function
 Function Remove-App([String]$AppName){
-	$PackageFullName = (Get-AppxPackage $AppName).PackageFullName
-	$ProPackageFullName = (Get-AppxProvisionedPackage -online | where {$_.Displayname -like $AppName}).PackageName
-	Remove-AppxPackage -package $PackageFullName | Out-Null
-	Remove-AppxProvisionedPackage -online -packagename $ProPackageFullName | Out-Null
+	If($AppxPackages.DisplayName -match $AppName) {
+		$PackageFullName = (Get-AppxPackage $AppName).PackageFullName
+		$ProPackageFullName = ($AppxPackages | where {$_.Displayname -like $AppName}).PackageName
+	
+		If($ProPackageFullName -is [array]){
+			For($i=0 ;$i -lt $ProPackageFullName.Length ;$i++) {
+				$Script:AppxCountMS++
+				$Job = "TronScriptMS$AppxCountMS"
+				$PackageF = $PackageFullName[$i]
+				$ProPackage = $ProPackageFullName[$i]
+				write-output "$AppxCountMS - $PackageF"
+				Start-Job -Name $Job -ScriptBlock { 
+					Remove-AppxPackage -Package $using:PackageF | Out-null
+					Remove-AppxProvisionedPackage -Online -PackageName $using:ProPackage | Out-null
+				} | Out-null
+			}
+		} Else {
+			$Script:AppxCountMS++
+			$Job = "TronScriptMS$AppxCountMS"
+			write-output "$AppxCountMS - $PackageFullName"
+			Start-Job -Name $Job -ScriptBlock { 
+				Remove-AppxPackage -Package $using:PackageFullName | Out-null
+				Remove-AppxProvisionedPackage -Online -PackageName $using:ProPackageFullName | Out-null
+			} | Out-null
+		}
+	}
 }
 
 ###########
@@ -102,3 +128,12 @@ Remove-App "Microsoft.Zune*"                           # Zune collection of apps
 #Remove-App "Microsoft.XboxGameOverlay"
 #Remove-App "Microsoft.XboxIdentityProvider"
 #Remove-App "Microsoft.XboxSpeechToTextOverlay"
+
+##########
+# Finish #
+##########
+# DO NOT REMOVE OR CHANGE (needs to be at end of script)
+# Waits for Apps to be removed before Script Closes
+Write-Output 'Finishing App Removal, Please Wait...'
+Wait-Job -Name "TronScriptMS*" | Out-Null
+Remove-Job -Name "TronScriptMS*" | Out-Null

--- a/resources/stage_2_de-bloat/metro/metro_Microsoft_modern_apps_to_target_by_name.ps1
+++ b/resources/stage_2_de-bloat/metro/metro_Microsoft_modern_apps_to_target_by_name.ps1
@@ -32,7 +32,7 @@ $METRO_MICROSOFT_MODERN_APPS_TO_TARGET_BY_NAME_SCRIPT_DATE = "2018-03-06"
 
 # Needed for Removal
 $AppxPackages = Get-AppxProvisionedPackage -online | select-object PackageName,Displayname
-$ProPackage = Get-AppxPackage | select-object PackageFullName, Name
+$ProPackage = Get-AppxPackage -AllUsers | select-object PackageFullName, Name
 $Script:AppxCount3rd = 0
 
 # App Removal function

--- a/resources/stage_2_de-bloat/metro/metro_Microsoft_modern_apps_to_target_by_name.ps1
+++ b/resources/stage_2_de-bloat/metro/metro_Microsoft_modern_apps_to_target_by_name.ps1
@@ -32,16 +32,17 @@ $METRO_MICROSOFT_MODERN_APPS_TO_TARGET_BY_NAME_SCRIPT_DATE = "2018-03-06"
 
 # Needed for Removal
 $AppxPackages = Get-AppxProvisionedPackage -online | select-object PackageName,Displayname
-$Script:AppxCountMS = 0
+$ProPackage = Get-AppxPackage | select-object PackageFullName, Name
+$Script:AppxCount3rd = 0
 
 # App Removal function
 Function Remove-App([String]$AppName){
-	If($AppxPackages.DisplayName -match $AppName) {
-		$PackageFullName = (Get-AppxPackage $AppName).PackageFullName
+	If($AppxPackages.DisplayName -match $AppName -or $ProPackage.Name -match $AppName ) {
+		$PackageFullName = ($ProPackage | where {$_.Name -like $AppName}).PackageFullName
 		$ProPackageFullName = ($AppxPackages | where {$_.Displayname -like $AppName}).PackageName
 	
-		If($ProPackageFullName -is [array]){
-			For($i=0 ;$i -lt $ProPackageFullName.Length ;$i++) {
+		If($PackageFullName -is [array]){
+			For($i=0 ;$i -lt $PackageFullName.Length ;$i++) {
 				$Script:AppxCountMS++
 				$Job = "TronScriptMS$AppxCountMS"
 				$PackageF = $PackageFullName[$i]

--- a/resources/stage_2_de-bloat/stage_2_de-bloat.bat
+++ b/resources/stage_2_de-bloat/stage_2_de-bloat.bat
@@ -303,8 +303,8 @@ if /i %TARGET_METRO%==yes (
 		REM Windows 10 version
 		if /i "%WIN_VER:~0,9%"=="Windows 1" (
 			REM Call the external PowerShell scripts to do removal of Microsoft and 3rd party OEM Modern Apps
-			powershell -executionpolicy bypass -file ".\stage_2_de-bloat\metro\metro_3rd_party_modern_apps_to_target_by_name.ps1"
-			powershell -executionpolicy bypass -file ".\stage_2_de-bloat\metro\metro_Microsoft_modern_apps_to_target_by_name.ps1"
+			START /WAIT powershell -executionpolicy bypass -file ".\stage_2_de-bloat\metro\metro_3rd_party_modern_apps_to_target_by_name.ps1"
+			START /WAIT powershell -executionpolicy bypass -file ".\stage_2_de-bloat\metro\metro_Microsoft_modern_apps_to_target_by_name.ps1"
 		)
 	)
 	call functions\log_with_date.bat "   Done."


### PR DESCRIPTION
Here is the change I was talking about.
The powershell script will now wait for all Metro Apps to finish uninstalling before the script it closed.

About 2 ps1 script files:
I am unable to test the 3rd party one (don't have any install I can use it on).
The Microsoft one works great, from what I tested.

I also made it give a list of apps it's removing along with a number before it.
If you don't want it to give the output just remove the 2 "write-out" lines in the function.

About the bat file files:
I added a "Wait" command in the bat file for the 2 ps1 script commands.. so the bat file wont keep going while the powershell script windows is open