### PR TITLE
#142:

### DIFF
--- a/tron.bat
+++ b/tron.bat
@@ -67,11 +67,11 @@ call functions\initialize_environment.bat %*
 :: Show help if requested
 for %%i in (%*) do ( if /i %%i==-h ( call :display_help && exit /b 0) )
 
-:: Do the pre-run checks and tasks (Admin rights check, temp directory check, SSD check etc)
-call functions\prerun_checks_and_tasks.bat
-
 :: Parse command-line arguments. If used these will override related settings specified in tron_settings.bat.
 call :parse_cmdline_args %*
+
+:: Do the pre-run checks and tasks (Admin rights check, temp directory check, SSD check etc)
+call functions\prerun_checks_and_tasks.bat
 
 :: Make sure user didn't pass -a and -asm together
 if /i %AUTORUN%==yes (


### PR DESCRIPTION
1. 

Parse the Command Line Arguments before Pre-Run Tasks and Tasks are run allowing unsupported operating system versions to run Tron when the message suggests using the `-dev` flag.