### PR TITLE
Wrong syntax for Reg key

### DIFF
--- a/resources/stage_1_tempclean/tempfilecleanup/TempFileCleanup.bat
+++ b/resources/stage_1_tempclean/tempfilecleanup/TempFileCleanup.bat
@@ -168,7 +168,7 @@ if exist %SystemDrive%\RECYCLER rmdir /s /q %SystemDrive%\RECYCLER
 if exist %SystemDrive%\$Recycle.Bin rmdir /s /q %SystemDrive%\$Recycle.Bin
 
 :: JOB: Clear MUI cache
-%REG% delete "HKCU\SOFTWARE\Classes\Local Settings\Muicache" /f
+%REG% del "HKCU\SOFTWARE\Classes\Local Settings\Muicache" /f
 
 :: JOB: Clear queued and archived Windows Error Reporting (WER) reports
 echo. >> %LOGPATH%\%LOGFILE%


### PR DESCRIPTION
:: JOB: Clear MUI cache
%REG% delete "HKCU\SOFTWARE\Classes\Local Settings\Muicache" /f

Delete for a regkey will not work and give a bad syntax error.
changed  to del