### PR TITLE
Fix disk space calculation under W11

### DIFF
--- a/resources/functions/prerun_checks_and_tasks.bat
+++ b/resources/functions/prerun_checks_and_tasks.bat
@@ -1,7 +1,8 @@
 :: Purpose:       Tron's pre-run checks. Various things to check before continuing on.
 :: Requirements:  Called by tron.bat during script initialization
 :: Author:        vocatus on reddit.com/r/TronScript ( vocatus.gate at gmail ) // PGP key: 0x07d1490f82a211a2
-:: Version:       1.1.2 * Update unsupported OS check to trigger on Windows XP, since we're deprecating support for it soon
+:: Version:       1.1.3 ! Fix disk space calculation on Win11 and up due to fsutil output changing.
+::                1.1.2 * Update unsupported OS check to trigger on Windows XP, since we're deprecating support for it soon
 ::                1.1.1 * Switch to alternate Administrator rights check
 ::                1.1.0 ! Fix regression re: disk space calculation fix
 ::                1.0.9 ! Fix disk space calculation on Win10 build 17763 (1809) and up due to fsutil output changing. Thanks to u/Paul_NZ
@@ -20,8 +21,8 @@
 
 
 :: Script version
-set PRERUN_CHECKS_SCRIPT_VERSION=1.1.2
-set PRERUN_CHECKS_SCRIPT_DATE=2020-03-04
+set PRERUN_CHECKS_SCRIPT_VERSION=1.1.3
+set PRERUN_CHECKS_SCRIPT_DATE=2022-08-15
 
 
 
@@ -162,8 +163,10 @@ popd
 
 
 :: TASK: Get free space on the system drive and stash it for comparison later
-for /f "tokens=2 delims=:(" %%a in ('fsutil volume diskfree %SystemDrive%') do set bytes=%%a
+for /f "tokens=2 delims=:(" %%a in ('fsutil volume diskfree %SystemDrive% ^| %FINDSTR% /i "avail free" ^| %FIND% /N " " ^| %FINDSTR% /l "[1]"') do set bytes=%%a
 set bytes=%bytes: =%
+set bytes=%bytes:,=%
+
 :: MB version
 set /A FREE_SPACE_BEFORE=%bytes:~0,-3%/1024*1000/1024
 

--- a/resources/stage_7_wrap-up/stage_7_wrap-up.bat
+++ b/resources/stage_7_wrap-up/stage_7_wrap-up.bat
@@ -1,7 +1,8 @@
 :: Purpose:       Sub-script containing all commands for Tron's Stage 7: Wrap-up stage. Called by tron.bat and returns control when finished
 :: Requirements:  Administrator access
 :: Author:        vocatus on reddit.com/r/TronScript ( vocatus.gate at gmail ) // PGP key: 0x07d1490f82a211a2
-:: Version:       1.0.4 - Remove post-run restore point creation, since there's really no point in creating it
+:: Version:       1.0.5 ! Apply W11 disk space calculation fix from prerun_checks_and_tasks.bat
+::                1.0.4 - Remove post-run restore point creation, since there's really no point in creating it
 ::                1.0.3 / Change REMOVE_MALWAREBYTES switch to PRESERVE_MALWAREBYTES (-pmb) as the new default behavior is to remove it at the end of the run
 ::                1.0.2 + Add REMOVE_MALWAREBYTES (-rmb) switch to have Tron automatically remove Malwarebytes at the end of the run
 ::                      / Change the display output from disk space reclaimed calculation to assume GB's instead of MB's
@@ -13,8 +14,8 @@
 :::::::::::::::::::::
 :: PREP AND CHECKS ::
 :::::::::::::::::::::
-set STAGE_7_SCRIPT_VERSION=1.0.4
-set STAGE_7_SCRIPT_DATE=2020-05-25
+set STAGE_7_SCRIPT_VERSION=1.0.5
+set STAGE_7_SCRIPT_DATE=2022-08-15
 
 :: Check for standalone vs. Tron execution and build the environment if running in standalone mode
 if /i "%LOGFILE%"=="" (
@@ -130,17 +131,18 @@ call functions\log_with_date.bat "   Done."
 
 :: JOB: Calculate saved disk space
 title Tron v%TRON_VERSION% [stage_7_wrap-up] [Calculate saved disk space]
-for /f "tokens=2 delims=:(" %%a in ('fsutil volume diskfree %SystemDrive%') do set bytes=%%a
+for /f "tokens=2 delims=:(" %%a in ('fsutil volume diskfree %SystemDrive% ^| %FINDSTR% /i "avail free" ^| %FIND% /N " " ^| %FINDSTR% /l "[1]"') do set bytes=%%a
 set bytes=%bytes: =%
+set bytes=%bytes:,=%
 
 :: Old method (broken in Win10 build 17763 (1809) and up)
 :: for /F "tokens=2 delims=:" %%a in ('fsutil volume diskfree %SystemDrive% ^| %FIND% /i "avail free"') do set bytes=%%a
 
 :: GB version of the calculation
-set /A FREE_SPACE_AFTER=%bytes:~0,-3%/1024*1000/1024/1024
+::set /A FREE_SPACE_AFTER=%bytes:~0,-3%/1024*1000/1024/1024
 
 :: MB version of the calculation
-::set /a FREE_SPACE_AFTER=%bytes:~0,-3%/1024*1000/1024
+set /a FREE_SPACE_AFTER=%bytes:~0,-3%/1024*1000/1024
 
 :: Set the space for display
 set /a FREE_SPACE_SAVED=%FREE_SPACE_AFTER% - %FREE_SPACE_BEFORE%


### PR DESCRIPTION
Under W10 21H2, `fsutil volume diskfree C:` outputs the following:
```
Total free bytes        :   367,475,556,352 (342.2 GB)
Total bytes             : 1,023,563,599,872 (953.3 GB)
Total quota free bytes  :   367,475,556,352 (342.2 GB)
```

Under W11 21H2 (different machine), we get:
```
Total free bytes                : 247,016,386,560 (230.1 GB)
Total bytes                     : 511,352,762,368 (476.2 GB)
Total quota free bytes          : 247,016,386,560 (230.1 GB)
Unavailable pool bytes          :               0 (  0.0 KB)
Quota unavailable pool bytes    :               0 (  0.0 KB)
Used bytes                      : 256,893,227,008 (239.3 GB)
Total Reserved bytes            :   7,443,148,800 (  6.9 GB)
Volume storage reserved bytes   :   7,372,722,176 (  6.9 GB)
Available committed bytes       :               0 (  0.0 KB)
Pool available bytes            :               0 (  0.0 KB)
```

Prior to this PR, `tron.bat -d -e` outputs upon completion:
```
                          Free space before Tron run: 367 MB
                          Free space after Tron run:  367 MB
                          Disk space reclaimed:       0 MB *
```

After:
```
                          Free space before Tron run: 350464 MB
                          Free space after Tron run:  350461 MB
                          Disk space reclaimed:       -3 MB *
```

(The -3 MB in this case is just because dry run doesn't kill a download I had in progress)